### PR TITLE
Add Database to Elastic Beanstalk and CD for Backend

### DIFF
--- a/.github/workflows/backend-testing.yml
+++ b/.github/workflows/backend-testing.yml
@@ -38,4 +38,4 @@ jobs:
       with:
         java-version: 11
     - name: Build and test with Maven
-      run: ./mvnw spring-boot:build-image -Dspring.profiles.active=staging
+      run: ./mvnw spring-boot:build-image

--- a/.github/workflows/staging-backend-deployment.yml
+++ b/.github/workflows/staging-backend-deployment.yml
@@ -1,25 +1,19 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Backend Tests with Maven
+name: Deploy Backend to Elastic Beanstalk
 
 on:
   push:
-    branches: # staging will be tested prior to deployment in a separate action
-      - main
-      - production
-  pull_request:
     branches:
-      - main
-      - production
       - staging
-
+      
 defaults:
   run:
     working-directory: server
 
 jobs:
-  test:
+  test-and-deploy:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -39,3 +33,12 @@ jobs:
         java-version: 11
     - name: Build and test with Maven
       run: ./mvnw spring-boot:build-image -Dspring.profiles.active=staging
+    - name: Deploy to EB
+      uses: einaregilsson/beanstalk-deploy@v16
+      with:
+        aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        application_name: ToDoBackend
+        environment_name: ToDoBackend-dev
+        region: us-west-1
+        deployment_package: target/todoapi-0.0.1-SNAPSHOT.jar

--- a/.github/workflows/staging-backend-deployment.yml
+++ b/.github/workflows/staging-backend-deployment.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - staging
-      
+
 defaults:
   run:
     working-directory: server
@@ -32,13 +32,13 @@ jobs:
       with:
         java-version: 11
     - name: Build and test with Maven
-      run: ./mvnw spring-boot:build-image -Dspring.profiles.active=staging
+      run: ./mvnw spring-boot:build-image
     - name: Deploy to EB
       uses: einaregilsson/beanstalk-deploy@v16
       with:
         aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         application_name: ToDoBackend
-        environment_name: ToDoBackend-dev
+        environment_name: ToDoBackend-staging
         region: us-west-1
         deployment_package: target/todoapi-0.0.1-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Clone the repo and follow the steps below.
 4. In your command-line interface go to the `server` directory within the project.
 5. Build and start the program:
    ```
-   ./mvnw spring-boot:run -Dspring.profiles.active=staging
+   ./mvnw spring-boot:run
    ```
 6. Once the server has started, visit `locahost:8080/health-check` in a browser to view status of the server.
 
@@ -204,7 +204,7 @@ These are the steps we took to deploy the frontend React app to an S3 bucket, an
     ```
     eb deploy
     ```
-8. Create environment variable in Elastic Beanstalk environment to specify server port (Spring defaults to `8080` while EB uses `5000`
+8. Create environment variable in Elastic Beanstalk environment to specify the profile
     ```
-    eb setenv SERVER_PORT=5000
+    eb setenv spring_profiles_active=aws
     ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Clone the repo and follow the steps below.
 4. In your command-line interface go to the `server` directory within the project.
 5. Build and start the program:
    ```
-   ./mvnw spring-boot:run
+   ./mvnw spring-boot:run -Dspring.profiles.active=staging
    ```
 6. Once the server has started, visit `locahost:8080/health-check` in a browser to view status of the server.
 

--- a/server/.elasticbeanstalk/config.yml
+++ b/server/.elasticbeanstalk/config.yml
@@ -1,6 +1,6 @@
 branch-defaults:
   default:
-    environment: ToDoBackend-staging
+    environment: ToDoBackend-dev
 deploy:
   artifact: target/todoapi-0.0.1-SNAPSHOT.jar
 global:

--- a/server/.elasticbeanstalk/config.yml
+++ b/server/.elasticbeanstalk/config.yml
@@ -1,6 +1,6 @@
 branch-defaults:
   default:
-    environment: ToDoBackend-dev
+    environment: ToDoBackend-staging
 deploy:
   artifact: target/todoapi-0.0.1-SNAPSHOT.jar
 global:

--- a/server/.elasticbeanstalk/config.yml
+++ b/server/.elasticbeanstalk/config.yml
@@ -1,0 +1,19 @@
+branch-defaults:
+  default:
+    environment: ToDoBackend-staging
+deploy:
+  artifact: target/todoapi-0.0.1-SNAPSHOT.jar
+global:
+  application_name: ToDoBackend
+  branch: null
+  default_ec2_keyname: null
+  default_platform: Corretto 11 running on 64bit Amazon Linux 2
+  default_region: us-west-1
+  include_git_submodules: true
+  instance_profile: null
+  platform_name: null
+  platform_version: null
+  profile: null
+  repository: null
+  sc: null
+  workspace_type: Application

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,5 @@
+
+# Elastic Beanstalk Files
+# .elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/server/src/main/resources/application-aws.properties
+++ b/server/src/main/resources/application-aws.properties
@@ -1,0 +1,5 @@
+# Server config
+server.port=${SERVER_PORT}
+
+## PostgreSQL
+spring.datasource.url=jdbc:postgresql://${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}

--- a/server/src/main/resources/application-staging.properties
+++ b/server/src/main/resources/application-staging.properties
@@ -1,0 +1,5 @@
+# Server config
+server.port=8080
+
+## PostgreSQL
+spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/todo

--- a/server/src/main/resources/application-staging.properties
+++ b/server/src/main/resources/application-staging.properties
@@ -1,5 +1,0 @@
-# Server config
-server.port=8080
-
-## PostgreSQL
-spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/todo

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Server config
+server.port=${SERVER_PORT}
+
 ## custom health check endpoint from actuator
 management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.health=health-check
@@ -7,7 +10,7 @@ spring.datasource.hikari.connectionTimeout=20000
 spring.datasource.hikari.maximumPoolSize=5
 
 ## PostgreSQL
-spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/todo
+spring.datasource.url=jdbc:postgresql://${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
 spring.datasource.username=postgres
 spring.datasource.password=postgres
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Server config
-server.port=${SERVER_PORT}
+server.port=8080
 
 ## custom health check endpoint from actuator
 management.endpoints.web.base-path=/
@@ -10,7 +10,7 @@ spring.datasource.hikari.connectionTimeout=20000
 spring.datasource.hikari.maximumPoolSize=5
 
 ## PostgreSQL
-spring.datasource.url=jdbc:postgresql://${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}
+spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/todo
 spring.datasource.username=postgres
 spring.datasource.password=postgres
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
- Added PostgreSQL database to Elastic Beanstalk environment.
- Created new profile with environment specific configuration (i.e., separate database config for AWS and local machine).
- Change Github Action to deploy on push to `staging` branch.

## More on "profile specific files"
### What is it?
They are configuration files specific to the profile (environment) you are running the program in. For example, you can use these to set different ports or database config for AWS and local.

### How does this PR use them?
- This PR creates a new profile, `application-aws.properties`. These are settings will be used in AWS and will override any properties also found in `application.properties`.
- I set a new environment variable, `spring_profiles_active`, to `aws` in AWS EB. 
  - This is documented in ReadMe.

### Other stuff I learned
- You can set the profile when running it from the CLI: `./mvnw spring-boot:run -Dspring.profiles.active=aws` (see update below)
  - The defaults in `application.properties` are set to what we would want on our local machine, so this is not necessary. 

**UPDATE (4/7/21)**: I wanted to clarify something above. When building a jar file, it's correct to use:
```
./mvnw spring-boot:run -Dspring.profiles.active=aws
``` 
However, when running it locally, it should be:
```
./mvnw spring-boot:run -Dspring-boot.run.profiles=aws
```


### Resources
- This [article](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.db.html) talks about the environment variables that will be available after adding a database (`RDS_HOSTNAME`, `RDS_PORT`, `RDS_DB_NAME`, etc.). 
- The [docs](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config) talks about which config files takes precedence.
- An [article](https://www.baeldung.com/spring-profiles#set-profiles) on how to set the profile.