### PR TITLE
API Endpoint to update to-do completion

### DIFF
--- a/server/src/main/java/com/kentaromatt/todoapi/ToDo.java
+++ b/server/src/main/java/com/kentaromatt/todoapi/ToDo.java
@@ -40,6 +40,8 @@ public class ToDo {
         return dueDate;
     }
 
+    public void setIsComplete(Boolean isComplete) { this.isComplete = isComplete; }
+
     public void toggleIsComplete() {
         isComplete = !isComplete;
     }

--- a/server/src/main/java/com/kentaromatt/todoapi/ToDo.java
+++ b/server/src/main/java/com/kentaromatt/todoapi/ToDo.java
@@ -39,4 +39,8 @@ public class ToDo {
     public LocalDate getDueDate() {
         return dueDate;
     }
+
+    public void toggleIsComplete() {
+        isComplete = !isComplete;
+    }
 }

--- a/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
+++ b/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
@@ -1,10 +1,13 @@
 package com.kentaromatt.todoapi;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -18,5 +21,13 @@ public class ToDoController {
     @GetMapping(path = "/todos")
     public @ResponseBody List<ToDo> getAllToDos() {
         return repository.findAll();
+    }
+
+    @PatchMapping(path = "/todo/{id}")
+    public @ResponseBody String updateToDo(@PathVariable String id) {
+        ToDo todo = repository.findById(UUID.fromString(id)).get();
+        todo.toggleIsComplete();
+        repository.save(todo);
+        return "{status: 'success'}";
     }
 }

--- a/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
+++ b/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
@@ -1,15 +1,13 @@
 package com.kentaromatt.todoapi;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping(path = "/api/")
@@ -24,10 +22,18 @@ public class ToDoController {
     }
 
     @PatchMapping(path = "/todo/{id}")
-    public @ResponseBody String updateToDo(@PathVariable String id) {
+    public @ResponseBody String updateToDo(@PathVariable String id, @RequestBody (required=false) CompletedReqBody completedReqBody) {
         ToDo todo = repository.findById(UUID.fromString(id)).get();
-        todo.toggleIsComplete();
+        todo.setIsComplete(completedReqBody.isComplete);
         repository.save(todo);
+
         return "{status: 'success'}";
+    }
+
+    static public class CompletedReqBody{
+        private Boolean isComplete;
+
+        public Boolean getIsComplete(){ return isComplete; }
+        public void setIsComplete(Boolean isComplete){ this.isComplete = isComplete; }
     }
 }

--- a/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
+++ b/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
@@ -1,11 +1,11 @@
 package com.kentaromatt.todoapi;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,15 +22,17 @@ public class ToDoController {
     }
 
     @PatchMapping(path = "/todo/{id}")
-    public @ResponseBody String updateToDo(@PathVariable String id, @RequestBody (required=false) CompletedReqBody completedReqBody) {
+    public @ResponseBody Map<String, String> updateToDo(@PathVariable String id, @RequestBody (required=false) CompletedReqBody completedReqBody) {
         ToDo todo = repository.findById(UUID.fromString(id)).get();
         todo.setIsComplete(completedReqBody.isComplete);
         repository.save(todo);
 
-        return "{status: 'success'}";
+        return new HashMap<>(){{
+            put("status", "success");
+        }};
     }
 
-    static public class CompletedReqBody{
+    static private class CompletedReqBody{
         private Boolean isComplete;
 
         public Boolean getIsComplete(){ return isComplete; }

--- a/server/src/test/java/com/kentaromatt/todoapi/ToDoControllerTest.java
+++ b/server/src/test/java/com/kentaromatt/todoapi/ToDoControllerTest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -90,5 +92,23 @@ public class ToDoControllerTest {
         mvc.perform(MockMvcRequestBuilders.get("/api/todos").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0]", hasKey("dueDate")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].dueDate", equalTo(dateStr)));
+    }
+
+    @Test
+    public void testUpdateToDosTogglesIsComplete() throws Exception {
+        ToDo todo = new ToDo("Feed cat");
+        repository.save(todo);
+
+        // Make sure todo.getIsComplete is false by default
+        assertFalse(todo.getIsComplete());
+
+        UUID id = todo.getId();
+        when(repository.findById(id)).thenReturn(java.util.Optional.of(todo));
+
+        mvc.perform(MockMvcRequestBuilders.patch("/api/todo/{%s}", id.toString()));
+
+        ToDo foundToDo = repository.findById(id).orElse(null);
+        assertNotNull(foundToDo);
+        assertTrue(foundToDo.getIsComplete());
     }
 }

--- a/server/src/test/java/com/kentaromatt/todoapi/ToDoControllerTest.java
+++ b/server/src/test/java/com/kentaromatt/todoapi/ToDoControllerTest.java
@@ -118,17 +118,27 @@ public class ToDoControllerTest {
     }
 
     @Test
-    public void testUpdateToDosSetsIsCompleteToTrue() throws Exception {
+    public void testUpdateSetIncompleteToComplete() throws Exception {
         ToDo todo = new ToDo("Feed cat");
         repository.save(todo);
 
-        // Make sure todo.getIsComplete is false by default
+        // Make sure todo.getIsComplete is originally false
         assertFalse(todo.getIsComplete());
 
         UUID id = todo.getId();
         when(repository.findById(id)).thenReturn(java.util.Optional.of(todo));
 
-        mvc.perform(MockMvcRequestBuilders.patch("/api/todo/{%s}", id.toString()));
+        Object requestBodyObject = new Object() {
+            public final Boolean isComplete = true;
+        };
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+
+        mvc.perform(
+                MockMvcRequestBuilders.patch("/api/todo/{%s}", id.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyJson)
+        );
 
         ToDo foundToDo = repository.findById(id).orElse(null);
         assertNotNull(foundToDo);
@@ -136,18 +146,85 @@ public class ToDoControllerTest {
     }
 
     @Test
-    public void testUpdateToDosSetsIsCompleteToFalse() throws Exception {
+    public void testUpdateSetsCompleteToIncomplete() throws Exception {
         ToDo todo = new ToDo("Feed cat");
-        todo.toggleIsComplete();
+        todo.setIsComplete(true);
         repository.save(todo);
 
-        // Make sure todo.getIsComplete is true by default
+        // Make sure todo.getIsComplete is originally true
         assertTrue(todo.getIsComplete());
 
         UUID id = todo.getId();
         when(repository.findById(id)).thenReturn(java.util.Optional.of(todo));
 
-        mvc.perform(MockMvcRequestBuilders.patch("/api/todo/{%s}", id.toString()));
+        Object requestBodyObject = new Object() {
+            public final Boolean isComplete = false;
+        };
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+
+        mvc.perform(
+                MockMvcRequestBuilders.patch("/api/todo/{%s}", id.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyJson)
+        );
+
+        ToDo foundToDo = repository.findById(id).orElse(null);
+        assertNotNull(foundToDo);
+        assertFalse(foundToDo.getIsComplete());
+    }
+
+    @Test
+    public void testUpdateSetsCompletedToCompleted() throws Exception {
+        ToDo todo = new ToDo("Feed cat");
+        todo.setIsComplete(true);
+        repository.save(todo);
+
+        // Make sure todo.getIsComplete is originally true
+        assertTrue(todo.getIsComplete());
+
+        UUID id = todo.getId();
+        when(repository.findById(id)).thenReturn(java.util.Optional.of(todo));
+
+        Object requestBodyObject = new Object() {
+            public final Boolean isComplete = true;
+        };
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+
+        mvc.perform(
+                MockMvcRequestBuilders.patch("/api/todo/{%s}", id.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyJson)
+        );
+
+        ToDo foundToDo = repository.findById(id).orElse(null);
+        assertNotNull(foundToDo);
+        assertTrue(foundToDo.getIsComplete());
+    }
+
+    @Test
+    public void testUpdateSetsIncompleteToIncomplete() throws Exception {
+        ToDo todo = new ToDo("Feed cat");
+        repository.save(todo);
+
+        // Make sure todo.getIsComplete is originally false
+        assertFalse(todo.getIsComplete());
+
+        UUID id = todo.getId();
+        when(repository.findById(id)).thenReturn(java.util.Optional.of(todo));
+
+        Object requestBodyObject = new Object() {
+            public final Boolean isComplete = false;
+        };
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+
+        mvc.perform(
+                MockMvcRequestBuilders.patch("/api/todo/{%s}", id.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyJson)
+        );
 
         ToDo foundToDo = repository.findById(id).orElse(null);
         assertNotNull(foundToDo);

--- a/server/src/test/java/com/kentaromatt/todoapi/ToDoControllerTest.java
+++ b/server/src/test/java/com/kentaromatt/todoapi/ToDoControllerTest.java
@@ -6,11 +6,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -90,6 +92,29 @@ public class ToDoControllerTest {
         mvc.perform(MockMvcRequestBuilders.get("/api/todos"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0]", hasKey("dueDate")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].dueDate", equalTo(dateStr)));
+    }
+
+    @Test
+    public void testUpdateToDosReturnsJson() throws Exception {
+        ToDo todo = new ToDo("Feed cat");
+        repository.save(todo);
+        UUID id = todo.getId();
+
+        when(repository.findById(id)).thenReturn(java.util.Optional.of(todo));
+
+        Object requestBodyObject = new Object() {
+            public final Boolean isComplete = true;
+        };
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+
+        mvc.perform(
+                MockMvcRequestBuilders.patch("/api/todo/{%s}", id.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyJson)
+        )
+                .andExpect(MockMvcResultMatchers.jsonPath("$", hasKey("status")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status", equalTo("success")));
     }
 
     @Test

--- a/server/src/test/java/com/kentaromatt/todoapi/ToDoTests.java
+++ b/server/src/test/java/com/kentaromatt/todoapi/ToDoTests.java
@@ -3,6 +3,7 @@ package com.kentaromatt.todoapi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 
@@ -38,5 +39,14 @@ public class ToDoTests {
         LocalDate date = LocalDate.now();
         ToDo todo = new ToDo("Walk dog", date);
         assertEquals(date, todo.getDueDate());
+    }
+
+    @Test
+    public void testToggleIsComplete() {
+        ToDo todo = new ToDo("Feed cat");
+        assertFalse(todo.getIsComplete());
+
+        todo.toggleIsComplete();
+        assertTrue(todo.getIsComplete());
     }
 }

--- a/server/src/test/java/com/kentaromatt/todoapi/ToDoTests.java
+++ b/server/src/test/java/com/kentaromatt/todoapi/ToDoTests.java
@@ -42,6 +42,24 @@ public class ToDoTests {
     }
 
     @Test
+    public void testSetIsComplete() {
+        ToDo todo = new ToDo("Feed cat");
+        assertFalse(todo.getIsComplete());
+
+        todo.setIsComplete(true);
+        assertTrue(todo.getIsComplete());
+
+        todo.setIsComplete(true);
+        assertTrue(todo.getIsComplete());
+
+        todo.setIsComplete(false);
+        assertFalse(todo.getIsComplete());
+
+        todo.setIsComplete(false);
+        assertFalse(todo.getIsComplete());
+    }
+
+    @Test
     public void testToggleIsComplete() {
         ToDo todo = new ToDo("Feed cat");
         assertFalse(todo.getIsComplete());


### PR DESCRIPTION
- Adds endpoint for setting a todo as complete or incomplete in the database.
  - It expects the to-do ID in the URL.
  - It expects `isComplete` (boolean) in the request body.
  - There is no validation, but this is a future card we hope to work on.