### PR TITLE
Add mapping for POST to /api/todos

### DIFF
--- a/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
+++ b/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
@@ -1,13 +1,16 @@
 package com.kentaromatt.todoapi;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @Controller
 @RequestMapping(path = "/api/")
@@ -30,6 +33,28 @@ public class ToDoController {
         return new HashMap<>(){{
             put("status", "success");
         }};
+    }
+
+    @PostMapping(path = "/todos")
+    public @ResponseBody HashMap<String, String> addToDo(@RequestBody HashMap<String, String> requestMap) {
+        if (!requestMap.containsKey("description") || requestMap.get("description") == "") {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Description is required");
+        }
+        String description = requestMap.get("description");
+        try {
+            LocalDate dueDate = LocalDate.parse(requestMap.get("dueDate"));
+            ToDo newToDo = new ToDo(description, dueDate);
+            repository.save(newToDo);
+            return new HashMap<String, String>(){{
+                put("id", newToDo.getId().toString());
+                put("description", newToDo.getDescription());
+                put("dueDate", newToDo.getDueDate().toString());
+                put("isComplete", newToDo.getIsComplete().toString());
+            }};
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "dueDate must be in format YYYY-MM-DD");
+        }
+
     }
 
     static private class CompletedReqBody{

--- a/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
+++ b/server/src/main/java/com/kentaromatt/todoapi/ToDoController.java
@@ -36,25 +36,21 @@ public class ToDoController {
     }
 
     @PostMapping(path = "/todos")
-    public @ResponseBody HashMap<String, String> addToDo(@RequestBody HashMap<String, String> requestMap) {
-        if (!requestMap.containsKey("description") || requestMap.get("description") == "") {
+    public @ResponseBody ToDo addToDo(@RequestBody HashMap<String, String> requestMap) {
+        if (!requestMap.containsKey("description") || requestMap.get("description") == null || requestMap.get("description").isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Description is required");
         }
-        String description = requestMap.get("description");
-        try {
-            LocalDate dueDate = LocalDate.parse(requestMap.get("dueDate"));
-            ToDo newToDo = new ToDo(description, dueDate);
-            repository.save(newToDo);
-            return new HashMap<String, String>(){{
-                put("id", newToDo.getId().toString());
-                put("description", newToDo.getDescription());
-                put("dueDate", newToDo.getDueDate().toString());
-                put("isComplete", newToDo.getIsComplete().toString());
-            }};
-        } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "dueDate must be in format YYYY-MM-DD");
+        LocalDate dueDate = null;
+        if (requestMap.containsKey("dueDate")) {
+            try {
+                dueDate = LocalDate.parse(requestMap.get("dueDate"));
+            } catch (Exception e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "dueDate must be in format YYYY-MM-DD");
+            }
         }
-
+        String description = requestMap.get("description");
+        ToDo newToDo = dueDate != null ? new ToDo(description, dueDate) : new ToDo(description);
+        return repository.save(newToDo);
     }
 
     static private class CompletedReqBody{

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Server config
 server.port=8080
+server.error.include-message=always
 
 ## custom health check endpoint from actuator
 management.endpoints.web.base-path=/

--- a/server/src/test/java/com/kentaromatt/todoapi/ToDoControllerTest.java
+++ b/server/src/test/java/com/kentaromatt/todoapi/ToDoControllerTest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -246,5 +247,77 @@ public class ToDoControllerTest {
                 .header("Access-Control-Request-Method", "GET")
                 .header("Origin", "http://localhost:3000"))
                 .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:3000"));
+    };
+
+    public void testPostToToDosReturns200OnSuccess() throws Exception {
+        Map<String, String> requestBodyObject = Map.of("description", "Feed cat", "dueDate", "2021-04-20");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+        
+        mvc.perform(
+            MockMvcRequestBuilders.post("/api/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson))
+                    .andExpect(MockMvcResultMatchers.status().is2xxSuccessful());
+    }
+
+    @Test
+    public void testPostToToDosReturnsJson() throws Exception {
+        Map<String, String> requestBodyObject = Map.of("description", "Walk cat", "dueDate", "2021-04-20");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+        
+        mvc.perform(
+            MockMvcRequestBuilders.post("/api/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.dueDate", equalTo("2021-04-20")))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.description", equalTo("Walk cat")))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.isComplete", equalTo("false")))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.id").exists());
+    }
+
+    @Test
+    public void testPostToToDosReturns400IfMissingDescription() throws Exception {
+        Map<String, String> requestBodyObject = Map.of("dueDate", "2021-04-20");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+        
+        mvc.perform(
+            MockMvcRequestBuilders.post("/api/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson))
+                    .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
+
+    @Test
+    public void testPostToToDosReturns400IfDescriptionIsEmptyString() throws Exception {
+        Map<String, String> requestBodyObject = Map.of("dueDate", "2021-04-20");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+        
+        mvc.perform(
+            MockMvcRequestBuilders.post("/api/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson))
+                    .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
+
+    @Test
+    public void testPostToToDosReturns400IfDateIsWrongFormat() throws Exception {
+        Map<String, String> requestBodyObject = Map.of("description", "Feed cat", "dueDate", "04-20-2021");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyJson = objectMapper.writeValueAsString(requestBodyObject);
+        
+        mvc.perform(
+            MockMvcRequestBuilders.post("/api/todos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson))
+                    .andExpect(MockMvcResultMatchers.status().is4xxClientError());
     }
 }


### PR DESCRIPTION
- Defines controller action for POST requests to `/api/todos` endpoint
- Returns a 400 error if `description` is missing from request body object, or if `dueDate` is in the wrong format
- On a success, returns 200 status and JSON object of newly-created `ToDo`